### PR TITLE
Make storage loading more defensive

### DIFF
--- a/src/main/java/seedu/duke/Resumake.java
+++ b/src/main/java/seedu/duke/Resumake.java
@@ -16,7 +16,7 @@ public class Resumake {
         list = new RecordList();
         try {
             list = storage.loadFromFile(Storage.getFilepath());
-        } catch (FileNotFoundException e) {
+        } catch (Exception e) {
             ui.showLoadingError();
         }
     }

--- a/src/main/java/seedu/duke/Storage.java
+++ b/src/main/java/seedu/duke/Storage.java
@@ -86,17 +86,26 @@ public class Storage {
         assert Files.exists(path) : "file should exist after path creation";
 
         Scanner sc = new Scanner(file);
-        while (sc.hasNext()) {
+        while (sc.hasNextLine()) {
             String line = sc.nextLine().strip();
-            if (!line.isEmpty()) {
+
+            if (line.isEmpty()) {
+                continue;
+            }
+
+            try {
                 Record record = parseRecord(line);
                 if (record != null) {
                     list.add(record);
                 } else {
                     logger.warning("Skipping invalid record line: " + line);
                 }
+            } catch (RuntimeException e) {
+                logger.warning("Unexpected error while loading line: " + line
+                        + " | Reason: " + e.getMessage());
             }
         }
+        sc.close();
         logger.info("Records loaded successfully");
         System.out.println("Loaded records from file.");
 
@@ -108,39 +117,72 @@ public class Storage {
     }
 
     private Record parseRecord(String line) {
+        assert line != null : "line should not be null";
+
         String trimmed = line.trim();
-        String[] split = trimmed.split("\\s+", 2);
-        if (split.length < 2) {
-            logger.fine("Unable to parse record line: " + line);
+        if (trimmed.isEmpty()) {
+            logger.fine("Skipping empty record line");
             return null;
         }
+
+        String[] split = trimmed.split("\\s+", 2);
+        if (split.length < 2) {
+            logger.warning("Invalid record line (missing arguments): " + line);
+            return null;
+        }
+
         String keyword = split[0].toLowerCase();
-        String args = split[1];
+        String args = split[1].trim();
+
         int roleIndex = args.indexOf("/role");
         int techIndex = args.indexOf("/tech");
         int fromIndex = args.indexOf("/from");
         int toIndex = args.indexOf("/to");
+
         if (roleIndex == -1 || techIndex == -1 || fromIndex == -1 || toIndex == -1) {
-            logger.fine("Missing fields while parsing line: " + line);
+            logger.warning("Invalid record line (missing required field(s)): " + line);
             return null;
         }
-        String title = args.substring(0, roleIndex).trim();
-        String role = args.substring(roleIndex + 5, techIndex).trim();
-        String tech = args.substring(techIndex + 5, fromIndex).trim();
-        String fromPart = args.substring(fromIndex + 5, toIndex).trim();
-        String toPart = args.substring(toIndex + 3).trim();
-        YearMonth from = YearMonth.parse(fromPart);
-        YearMonth to = YearMonth.parse(toPart);
 
-        switch (keyword) {
-        case "project":
-            return new Project(title, role, tech, from, to);
-        case "experience":
-            return new Experience(title, role, tech, from, to);
-        case "cca":
-            return new Cca(title, role, tech, from, to);
-        default:
-            logger.fine("Unknown record keyword while parsing: " + keyword);
+        if (!(roleIndex < techIndex && techIndex < fromIndex && fromIndex < toIndex)) {
+            logger.warning("Invalid record line (fields are in wrong order): " + line);
+            return null;
+        }
+
+        try {
+            String title = args.substring(0, roleIndex).trim();
+            String role = args.substring(roleIndex + 5, techIndex).trim();
+            String tech = args.substring(techIndex + 5, fromIndex).trim();
+            String fromPart = args.substring(fromIndex + 5, toIndex).trim();
+            String toPart = args.substring(toIndex + 3).trim();
+
+            if (title.isEmpty() || role.isEmpty() || tech.isEmpty()
+                    || fromPart.isEmpty() || toPart.isEmpty()) {
+                logger.warning("Invalid record line (field value is empty): " + line);
+                return null;
+            }
+
+            YearMonth from = YearMonth.parse(fromPart);
+            YearMonth to = YearMonth.parse(toPart);
+
+            if (to.isBefore(from)) {
+                logger.warning("Invalid record line (end date cannot be before start date): " + line);
+                return null;
+            }
+
+            switch (keyword) {
+            case "project":
+                return new Project(title, role, tech, from, to);
+            case "experience":
+                return new Experience(title, role, tech, from, to);
+            case "cca":
+                return new Cca(title, role, tech, from, to);
+            default:
+                logger.warning("Unknown record keyword while parsing: " + keyword);
+                return null;
+            }
+        } catch (RuntimeException e) {
+            logger.warning("Failed to parse record line: " + line + " | Reason: " + e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
This version of Storage.java now safely handles:
blank lines
missing arguments
missing /role, /tech, /from, /to
wrong field order
empty title/role/tech/date fields
invalid YearMonth
end date before start date
unknown record type

Instead of crashing, it logs and returns null, so loadFromFile(...) can skip that line. This matches our current way loadFromFile(...) already tries to skip invalid records when parseRecord(...) returns null.

If some future code accidentally throws from parseRecord(...), loading will still continue for the rest of the file instead of crashing the entire app.