### PR TITLE
Fix issue 167 for FindCommand

### DIFF
--- a/src/main/java/seedu/duke/commands/FindCommand.java
+++ b/src/main/java/seedu/duke/commands/FindCommand.java
@@ -76,9 +76,8 @@ public class FindCommand extends Command {
             ui.showMessage("Matching records:");
 
             boolean hasMatch = false;
-            int displayIndex = 1;
-
-            for (Record record : list) {
+            for (int index = 0; index < list.getSize(); index++) {
+                Record record = list.getRecord(index);
                 assert record != null : "Record in RecordList should not be null";
 
                 if (record == null) {
@@ -90,8 +89,7 @@ public class FindCommand extends Command {
 
                 if (record.containsKeyword(keyword)) {
                     logger.info("Match found for keyword \"" + keyword + "\": " + record.getTitle());
-                    ui.showMessage(displayIndex + ". " + record);
-                    displayIndex++;
+                    ui.showMessage((index + 1) + ". " + record);
                     hasMatch = true;
                 }
             }

--- a/src/test/java/seedu/duke/FindCommandTest.java
+++ b/src/test/java/seedu/duke/FindCommandTest.java
@@ -135,6 +135,26 @@ public class FindCommandTest {
     }
 
     @Test
+    public void execute_sparseMatch_printsOriginalListIndex() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        RecordList recordList = fillRecordList();
+
+        FindCommand findCommand = new FindCommand("internship");
+        findCommand.execute(recordList);
+
+        String lineSeparator = System.lineSeparator();
+        String expectedOutput = "--------------------" + lineSeparator
+                + "Matching records:" + lineSeparator
+                + "2. [R] Python internship | role: Developer | tech: Java | from: 2026-01 | to: 2026-03"
+                + lineSeparator
+                + "--------------------" + lineSeparator;
+
+        assertEquals(expectedOutput, outputStream.toString());
+    }
+
+    @Test
     public void constructor_nullKeyword_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> new FindCommand(null));
     }


### PR DESCRIPTION
Implemented the fix so find now shows the same record number as list (global list index), not match-local numbering.

What changed:
- find now iterates by actual RecordList index and prints index + 1 for each match.
- Added a regression test where only the second record matches (internship) and asserted output starts with 2..