### PR TITLE
Update FindBullet to show actual index in record

### DIFF
--- a/src/main/java/seedu/duke/commands/FindBulletCommand.java
+++ b/src/main/java/seedu/duke/commands/FindBulletCommand.java
@@ -87,7 +87,8 @@ public class FindBulletCommand extends Command {
                 int matchCount = 0;
                 StringBuilder bulletOutput = new StringBuilder();
 
-                for (String bullet : bullets) {
+                for (int i = 0; i < bullets.size(); i++) {
+                    String bullet = bullets.get(i);
                     if (bullet == null) {
                         continue;
                     }
@@ -95,7 +96,7 @@ public class FindBulletCommand extends Command {
                     if (bullet.toLowerCase().contains(lowerKeyword)) {
                         matchCount++;
                         bulletOutput.append("  ")
-                                .append(matchCount)
+                                .append(i + 1)
                                 .append(". ")
                                 .append(bullet)
                                 .append(System.lineSeparator());

--- a/src/test/java/seedu/duke/FindBulletCommandTest.java
+++ b/src/test/java/seedu/duke/FindBulletCommandTest.java
@@ -78,6 +78,37 @@ public class FindBulletCommandTest {
     }
 
     @Test
+    public void execute_multipleMatchingBullets_printsOriginalBulletIndices() throws ResumakeException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
+        RecordList list = new RecordList();
+        Record record = new Project(
+                "Capo CLI",
+                "Developer",
+                "Java",
+                YearMonth.parse("2026-01"),
+                YearMonth.parse("2026-03")
+        );
+        record.addBullet("foo");
+        record.addBullet("bar");
+        record.addBullet("foo2");
+        list.add(record);
+
+        FindBulletCommand command = new FindBulletCommand("foo");
+        command.execute(list);
+
+        String lineSeparator = System.lineSeparator();
+        String expectedOutput = "1. [P] Capo CLI | role: Developer | tech: Java | from: 2026-01 | to: 2026-03"
+                + lineSeparator
+                + "Bullets:" + lineSeparator
+                + "  1. foo" + lineSeparator
+                + "  3. foo2" + lineSeparator;
+
+        assertEquals(expectedOutput, outputStream.toString());
+    }
+
+    @Test
     public void execute_noMatchingBullets_printsNoMatchMessage() throws ResumakeException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outputStream));
@@ -163,7 +194,7 @@ public class FindBulletCommandTest {
         String expectedOutput = "1. [P] Capo CLI | role: Developer | tech: Java | from: 2026-01 | to: 2026-03"
                 + lineSeparator
                 + "Bullets:" + lineSeparator
-                + "  1. Implemented persistent storage with file IO" + lineSeparator;
+                + "  2. Implemented persistent storage with file IO" + lineSeparator;
 
         assertEquals(expectedOutput, outputStream.toString());
     }


### PR DESCRIPTION
What was wrong
- findbullet was numbering matches by match order (1, 2, ...) instead of the bullet’s actual index in the record.
- So deletebullet RECORD_INDEX BULLET_INDEX could delete the wrong bullet if we copied the number from findbullet.


Fix applied
Updated findbullet to print original bullet indices (the same index space used by show/deletebullet):
FindBulletCommand.java:90
Added/updated tests:
New regression test for non-consecutive matches showing 1 and 3:
FindBulletCommandTest.java:81
Updated null-bullet edge-case expectation to keep index semantics consistent:
FindBulletCommandTest.java:174