### PR TITLE
Wei hao fix findcommand and movebullet bugs

### DIFF
--- a/docs/team/woshiweiha0.md
+++ b/docs/team/woshiweiha0.md
@@ -60,6 +60,8 @@ Given below are my contributions to the project.
 - Helped align command documentation with implemented behavior before release checks.
 - Strengthened team-wide confidence in core flows by adding regression tests for app runtime, UI output consistency, and storage defensive behavior.
 
+<div style="page-break-after: always;"></div>
+
 ### Contributions beyond the project team
 
 - Conducted PE-D for another team and reported a high number of actionable bugs (21), then followed up with peer input to clarify impact and improve fixability.

--- a/src/main/java/seedu/duke/commands/FindCommand.java
+++ b/src/main/java/seedu/duke/commands/FindCommand.java
@@ -70,8 +70,6 @@ public class FindCommand extends Command {
                 throw new IllegalArgumentException("RecordList cannot be null.");
             }
 
-            assert list != null : "RecordList passed to FindCommand should not be null";
-
             ui.showLine();
             ui.showMessage("Matching records:");
 

--- a/src/main/java/seedu/duke/commands/MoveBulletCommand.java
+++ b/src/main/java/seedu/duke/commands/MoveBulletCommand.java
@@ -65,6 +65,15 @@ public class MoveBulletCommand extends Command {
             Record record = list.getRecord(recordIndex);
             assert record != null : "Record at valid index should not be null";
 
+            if (fromBulletIndex == toBulletIndex) {
+                ui.showLine();
+                ui.showMessage("No changes made: bullet is already at position "
+                        + (fromBulletIndex + 1) + " in record " + (recordIndex + 1) + ".");
+                ui.showLine();
+                logger.info("MoveBulletCommand skipped: source and target indices are the same");
+                return;
+            }
+
             record.moveBullet(fromBulletIndex, toBulletIndex);
 
             ui.showLine();

--- a/src/test/java/seedu/duke/FindBulletCommandTest.java
+++ b/src/test/java/seedu/duke/FindBulletCommandTest.java
@@ -151,7 +151,10 @@ public class FindBulletCommandTest {
     }
 
     @Test
-    public void execute_nullRecordInList_throwsAssertionError() throws ResumakeException {
+    public void execute_nullRecordInList_ignoredAndValidRecordsStillShown() throws ResumakeException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
         RecordList list = new RecordList();
         list.add(null);
 
@@ -167,7 +170,15 @@ public class FindBulletCommandTest {
         list.add(record);
 
         FindBulletCommand command = new FindBulletCommand("persistent");
-        assertThrows(AssertionError.class, () -> command.execute(list));
+        command.execute(list);
+
+        String lineSeparator = System.lineSeparator();
+        String expectedOutput = "1. [P] Capo CLI | role: Developer | tech: Java | from: 2026-01 | to: 2026-03"
+                + lineSeparator
+                + "Bullets:" + lineSeparator
+                + "  2. Implemented persistent storage with file IO" + lineSeparator;
+
+        assertEquals(expectedOutput, outputStream.toString());
     }
 
     @Test

--- a/src/test/java/seedu/duke/FindCommandTest.java
+++ b/src/test/java/seedu/duke/FindCommandTest.java
@@ -182,7 +182,10 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_nullRecordInList_throwsAssertionError() {
+    public void execute_nullRecordInList_ignoredAndValidRecordsStillShown() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
         RecordList list = new RecordList();
         list.add(null);
         list.add(new Record(
@@ -194,6 +197,15 @@ public class FindCommandTest {
         ));
 
         FindCommand findCommand = new FindCommand("java");
-        assertThrows(AssertionError.class, () -> findCommand.execute(list));
+        findCommand.execute(list);
+
+        String lineSeparator = System.lineSeparator();
+        String expectedOutput = "--------------------" + lineSeparator
+                + "Matching records:" + lineSeparator
+                + "1. [R] Java capstone | role: Developer | tech: Java | from: 2026-01 | to: 2026-03"
+                + lineSeparator
+                + "--------------------" + lineSeparator;
+
+        assertEquals(expectedOutput, outputStream.toString());
     }
 }

--- a/src/test/java/seedu/duke/MoveBulletCommandTest.java
+++ b/src/test/java/seedu/duke/MoveBulletCommandTest.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.duke.commands.MoveBulletCommand;
@@ -17,6 +18,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MoveBulletCommandTest {
     private final PrintStream originalOut = System.out;
+
+    @BeforeEach
+    public void setUp() {
+        User.loadFrom("John", 91234567, "john@example.com");
+    }
 
     @AfterEach
     public void restoreSystemStreams() {
@@ -64,6 +70,9 @@ public class MoveBulletCommandTest {
 
     @Test
     public void execute_moveBulletSameIndex_noChange() throws ResumakeException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+
         RecordList list = new RecordList();
         Record record = createRecordWithThreeBullets();
         list.add(record);
@@ -75,6 +84,11 @@ public class MoveBulletCommandTest {
         assertEquals("A", record.getBullets().get(0));
         assertEquals("B", record.getBullets().get(1));
         assertEquals("C", record.getBullets().get(2));
+        assertEquals("--------------------" + System.lineSeparator()
+                        + "No changes made: bullet is already at position 2 in record 1."
+                        + System.lineSeparator()
+                        + "--------------------" + System.lineSeparator(),
+                outputStream.toString());
     }
 
     @Test


### PR DESCRIPTION
Changed movebullet so it no longer prints a success “moved” message when source and target indices are the same.

Command fix: MoveBulletCommand.java:68
Now it prints:
No changes made: bullet is already at position X in record Y.
Regression test update: MoveBulletCommandTest.java:72
Added assertion for the no-op message and added @BeforeEach user init so this test class is stable when run in isolation.