### PR TITLE
Fix Move Bullet accepting impossible equal indices

### DIFF
--- a/src/main/java/seedu/duke/commands/MoveBulletCommand.java
+++ b/src/main/java/seedu/duke/commands/MoveBulletCommand.java
@@ -65,16 +65,18 @@ public class MoveBulletCommand extends Command {
         Record record = list.getRecord(recordIndex);
         assert record != null : "Record at valid index should not be null";
 
-        if (fromBulletIndex == toBulletIndex) {
-            ui.showLine();
-            ui.showMessage("No changes made: bullet is already at position "
-                    + (fromBulletIndex + 1) + " in record " + (recordIndex + 1) + ".");
-            ui.showLine();
-            logger.info("MoveBulletCommand skipped: source and target indices are the same");
-            return;
-        }
-
         try {
+            if (fromBulletIndex == toBulletIndex) {
+                // Use record.moveBullet to validate bounds even for no-op moves.
+                record.moveBullet(fromBulletIndex, toBulletIndex);
+                ui.showLine();
+                ui.showMessage("No changes made: bullet is already at position "
+                        + (fromBulletIndex + 1) + " in record " + (recordIndex + 1) + ".");
+                ui.showLine();
+                logger.info("MoveBulletCommand skipped: source and target indices are the same");
+                return;
+            }
+
             record.moveBullet(fromBulletIndex, toBulletIndex);
 
             ui.showLine();

--- a/src/test/java/seedu/duke/MoveBulletCommandTest.java
+++ b/src/test/java/seedu/duke/MoveBulletCommandTest.java
@@ -94,6 +94,22 @@ public class MoveBulletCommandTest {
     }
 
     @Test
+    public void execute_moveBulletSameOutOfRangeIndex_throwsInvalidBulletIndex() throws ResumakeException {
+        RecordList list = new RecordList();
+        Record record = createRecordWithThreeBullets();
+        list.add(record);
+
+        MoveBulletCommand command = new MoveBulletCommand(0, 98, 98);
+        ResumakeException ex = assertThrows(ResumakeException.class, () -> command.execute(list));
+        assertEquals("Invalid bullet index.", ex.getMessage());
+
+        assertEquals(3, record.getBullets().size());
+        assertEquals("A", record.getBullets().get(0));
+        assertEquals("B", record.getBullets().get(1));
+        assertEquals("C", record.getBullets().get(2));
+    }
+
+    @Test
     public void execute_invalidRecordIndex_noMutation() throws ResumakeException {
         RecordList list = new RecordList();
         Record record = createRecordWithThreeBullets();


### PR DESCRIPTION
- Updated MoveBulletCommand.java (line 77) so equal indices are validated through record.moveBullet(...) before showing the no-op message.
- his means invalid equal indices like movebullet 1 99 99 now throw ResumakeException("Invalid bullet index.") instead of printing a misleading no-op message.
- Added regression test MoveBulletCommandTest.java (line 96) for same out-of-range indices (98, 98 internal zero-based).