### PR TITLE
Fix slash token parsing bug in Parser

### DIFF
--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -578,10 +578,9 @@ public class Parser {
         int toIndex = -1;
 
         Matcher matcher = FIELD_TOKEN_PATTERN.matcher(args);
-        boolean roleSeen = false;
-        boolean techSeen = false;
-        boolean fromSeen = false;
-        boolean toSeen = false;
+        String[] unknownTokens = new String[4];
+        int[] unknownTokenIndices = new int[4];
+        int unknownCount = 0;
 
         while (matcher.find()) {
             String fieldToken = matcher.group(1);
@@ -613,14 +612,44 @@ public class Parser {
                 toIndex = tokenIndex;
                 break;
             default:
+                if (unknownCount == unknownTokens.length) {
+                    String[] expandedTokens = new String[unknownCount * 2];
+                    int[] expandedIndices = new int[unknownCount * 2];
+                    System.arraycopy(unknownTokens, 0, expandedTokens, 0, unknownCount);
+                    System.arraycopy(unknownTokenIndices, 0, expandedIndices, 0, unknownCount);
+                    unknownTokens = expandedTokens;
+                    unknownTokenIndices = expandedIndices;
+                }
+                unknownTokens[unknownCount] = fieldToken;
+                unknownTokenIndices[unknownCount] = tokenIndex;
+                unknownCount++;
+            }
+        }
+
+        int firstKnownFieldIndex = args.length();
+        if (roleIndex != -1 && roleIndex < firstKnownFieldIndex) {
+            firstKnownFieldIndex = roleIndex;
+        }
+        if (techIndex != -1 && techIndex < firstKnownFieldIndex) {
+            firstKnownFieldIndex = techIndex;
+        }
+        if (fromIndex != -1 && fromIndex < firstKnownFieldIndex) {
+            firstKnownFieldIndex = fromIndex;
+        }
+        if (toIndex != -1 && toIndex < firstKnownFieldIndex) {
+            firstKnownFieldIndex = toIndex;
+        }
+
+        for (int i = 0; i < unknownCount; i++) {
+            if (unknownTokenIndices[i] >= firstKnownFieldIndex) {
                 if (isEditCommand) {
-                    throw new ResumakeException("\"" + fieldToken
+                    throw new ResumakeException("\"" + unknownTokens[i]
                             + "\" is not a valid field. Please use the following format "
                             + "\"edit RECORD_INDEX [NEW_TITLE] [/role NEW_ROLE] [/tech NEW_TECH] "
                             + "[/from YYYY-MM] [/to YYYY-MM]\".");
                 }
                 throw new ResumakeException(
-                        "\"" + fieldToken + "\" is not a valid field. "
+                        "\"" + unknownTokens[i] + "\" is not a valid field. "
                                 + "Please use /role, /tech, /from, and /to only.");
             }
         }

--- a/src/test/java/seedu/duke/ParserTest.java
+++ b/src/test/java/seedu/duke/ParserTest.java
@@ -452,6 +452,42 @@ public class ParserTest {
     }
 
     @Test
+    public void parse_projectTitleContainingStandaloneSlashToken_parsesCorrectly() throws Exception {
+        provideInput("n");
+        Command command = Parser.parse(
+                "project Resume /Builder /role Developer /tech Java /from 2026-01 /to 2026-03");
+        assertInstanceOf(AddCommand.class, command);
+
+        RecordList list = new RecordList();
+        command.execute(list);
+
+        Record record = list.getRecord(0);
+        assertEquals("Resume /Builder", record.getTitle());
+        assertEquals("Developer", record.getRole());
+    }
+
+    @Test
+    public void parse_editTitleContainingStandaloneSlashToken_parsesCorrectly() throws Exception {
+        Command command = Parser.parse("edit 1 Resume /Builder /role Team Lead");
+        assertInstanceOf(EditCommand.class, command);
+
+        RecordList list = new RecordList();
+        Record record = new Record(
+                "Old Title",
+                "Developer",
+                "Java",
+                YearMonth.parse("2026-01"),
+                YearMonth.parse("2026-03"));
+        list.add(record);
+
+        command.execute(list);
+
+        assertEquals("Resume /Builder", record.getTitle());
+        assertEquals("Team Lead", record.getRole());
+        assertEquals("Java", record.getTech());
+    }
+
+    @Test
     public void parse_projectDuplicateField_throwsException() {
         ResumakeException exception = assertThrows(ResumakeException.class, () -> Parser.parse(
                 "project Demo /role First /role Second /tech Java /from 2026-01 /to 2026-03"));


### PR DESCRIPTION
Updated Parser.java (line 574) (findFieldIndices) to:
- Collect unknown slash tokens first.
- Allow unknown slash tokens before the first valid field flag (treated as title text, e.g. /Builder).
- Still reject unknown slash fields that appear once field parsing has started (so /salary still errors).
- Added regression tests in ParserTest.java (line 455):
- project Resume /Builder /role ... now parses correctly.
- edit 1 Resume /Builder /role ... now parses correctly.